### PR TITLE
Add support to reuse transformer weights across long sequences

### DIFF
--- a/eir/models/sequence/transformer_basic.py
+++ b/eir/models/sequence/transformer_basic.py
@@ -1,99 +1,90 @@
 import math
 from dataclasses import dataclass
-from typing import Union, Literal, Type
+from typing import Union, Literal, Type, Callable, Tuple, Dict
+from functools import partial
 
 import torch
 from aislib.misc_utils import get_logger
 from torch import nn, Tensor
 from torch.nn import TransformerEncoder, TransformerEncoderLayer
+from torch.nn.functional import pad
+
+from eir.models.layers import _find_split_padding_needed
 
 logger = get_logger(name=__name__, tqdm_compatible=True)
 
 
 @dataclass
-class BasicTransformerModelConfig:
+class TransformerWrapperModelConfig:
     """
     :param embedding_dim:
         Which dimension to use for the embeddings. If ``None``, will autoamtically set
         this value based on the number of tokens and attention heads.
 
-    :param num_heads:
-        The number of heads in the multi-head attention models
-
-    :param num_layers:
-        The number of encoder blocks in the transformer model.
-
-    :param dropout:
-        Common dropout value to use in (a) the positional encoding and (b) the encoder
-        layers.
-
     :param position:
         Whether to use positional encodings or embeddings for representing token
         positions.
+
+    :param position_dropout:
+        Dropout to use in the positional encoding/embeddings.
+
+    :param window_size:
+        If set to more than 0, will apply a sliding window of feature
+        extraction over the input, meaning the model (e.g. transformer) will only
+        see a part of the input at a time. Can be Useful to avoid the O(n²)
+        complexity of transformers, as it becomes n_windows * O(window_size²) instead.
     """
 
-    embedding_dim: Union[int, None] = None
-    num_heads: int = 8
-    num_layers: int = 2
-    dropout: float = 0.10
     position: Literal["encode", "embed"] = "encode"
+    position_dropout: float = 0.10
+    window_size: int = 0
 
 
-class TransformerModel(nn.Module):
+class TransformerWrapperModel(nn.Module):
     def __init__(
         self,
-        model_config: BasicTransformerModelConfig,
+        feature_extractor: "TransformerFeatureExtractor",
+        model_config: TransformerWrapperModelConfig,
+        embedding_dim: int,
         num_tokens: int,
         max_length: int,
     ) -> None:
-        super().__init__()
 
+        super().__init__()
         self.model_config = model_config
+        self.embedding_dim = embedding_dim
         self.num_tokens = num_tokens
         self.max_length = max_length
-
-        self.embedding_dim = model_config.embedding_dim
-        if self.model_config.embedding_dim is None:
-            auto_emb_dim = (
-                math.ceil((int(num_tokens ** 0.25) / self.model_config.num_heads))
-                * self.model_config.num_heads
-            )
-            logger.info(
-                "Setting up automatic embedding dimension of %d based on %d "
-                "tokens and %d attention heads.",
-                auto_emb_dim,
-                self.num_tokens,
-                self.model_config.num_heads,
-            )
-            self.embedding_dim = auto_emb_dim
 
         pos_repr_class = get_positional_representation_class(
             position_model_config=self.model_config.position
         )
         self.pos_representation = pos_repr_class(
             embedding_dim=self.embedding_dim,
-            dropout=model_config.dropout,
+            dropout=model_config.position_dropout,
             max_length=self.max_length,
-        )
-        encoder_layers = TransformerEncoderLayer(
-            d_model=self.embedding_dim,
-            nhead=model_config.num_heads,
-            dim_feedforward=self.max_length,
-            dropout=model_config.dropout,
-            batch_first=True,
-        )
-        self.transformer_encoder = TransformerEncoder(
-            encoder_layer=encoder_layers, num_layers=model_config.num_layers
         )
         self.embedding = nn.Embedding(
             num_embeddings=self.num_tokens, embedding_dim=self.embedding_dim
         )
 
+        self.feature_extractor = feature_extractor
+
         self.init_weights()
+
+        (
+            self.dynamic_extras,
+            self.extract_features,
+        ) = _get_transformer_wrapper_feature_extractor(
+            feature_extractor=self.feature_extractor,
+            window_size=self.model_config.window_size,
+            max_length=max_length,
+        )
 
     @property
     def num_out_features(self) -> int:
-        return self.max_length * self.embedding_dim
+        padding = self.dynamic_extras.get("padding", 0)
+        return (self.max_length + padding) * self.embedding_dim
 
     def embed_tokens(self, input: torch.Tensor) -> torch.Tensor:
         return self.embedding(input)
@@ -103,10 +94,153 @@ class TransformerModel(nn.Module):
         self.embedding.weight.data.uniform_(-init_range, init_range)
 
     def forward(self, input: Tensor) -> Tensor:
-
         out = input * math.sqrt(self.embedding_dim)
         out = self.pos_representation(out)
-        out = self.transformer_encoder(out)
+        out = self.extract_features(out)
+
+        return out
+
+
+def get_embedding_dim_for_sequence_model(
+    embedding_dim: Union[None, int], num_tokens: int, num_heads: int
+) -> int:
+
+    if embedding_dim is None:
+        auto_emb_dim = math.ceil((int(num_tokens ** 0.25) / num_heads)) * num_heads
+        logger.info(
+            "Setting up automatic embedding dimension of %d based on %d "
+            "tokens and %d attention heads.",
+            auto_emb_dim,
+            num_tokens,
+            num_heads,
+        )
+        embedding_dim = auto_emb_dim
+
+    return embedding_dim
+
+
+def _get_transformer_wrapper_feature_extractor(
+    feature_extractor: "TransformerFeatureExtractor",
+    window_size: int,
+    max_length: int,
+) -> Tuple[Dict, Callable[[torch.Tensor], torch.Tensor]]:
+
+    dynamic_extras = {}
+    if not window_size:
+        extractor = partial(
+            _simple_transformer_forward, feature_extractor=feature_extractor
+        )
+    else:
+        num_chunks = int(math.ceil(max_length / window_size))
+        logger.debug(
+            "Setting num chunks to %d as window size of %d and maximum sequence length "
+            "of %d were passed in.",
+            num_chunks,
+            window_size,
+            max_length,
+        )
+
+        padding = _find_split_padding_needed(
+            input_size=max_length,
+            split_size=window_size,
+            num_chunks=num_chunks,
+        )
+        dynamic_extras["padding"] = padding
+
+        extractor = partial(
+            _conv_transfomer_forward,
+            feature_extractor=feature_extractor,
+            max_length=max_length,
+            window_size=window_size,
+            padding=padding,
+        )
+
+    return dynamic_extras, extractor
+
+
+def _simple_transformer_forward(
+    input: torch.Tensor, feature_extractor: "TransformerFeatureExtractor"
+) -> torch.Tensor:
+    return feature_extractor(input=input)
+
+
+def _conv_transfomer_forward(
+    input: torch.Tensor,
+    feature_extractor: "TransformerFeatureExtractor",
+    max_length: int,
+    window_size: int,
+    padding: int,
+) -> torch.Tensor:
+
+    out = pad(input=input, pad=[0, 0, padding, 0])
+    total_length = max_length + padding
+
+    aggregated_out = None
+    for lower_index in range(0, total_length, window_size):
+        upper_index = lower_index + window_size
+
+        cur_input = out[:, lower_index:upper_index, :]
+        cur_out = feature_extractor(input=cur_input).flatten(1)
+
+        if aggregated_out is None:
+            aggregated_out = cur_out
+        else:
+            aggregated_out = torch.cat((aggregated_out, cur_out), dim=1)
+
+    return aggregated_out
+
+
+@dataclass
+class BasicTransformerFeatureExtractorModelConfig:
+    """
+    :param num_heads:
+        The number of heads in the multi-head attention models
+
+    :param num_layers:
+        The number of encoder blocks in the transformer model.
+
+    :param dropout:
+         Dropout value to use in the encoder layers.
+
+    """
+
+    num_heads: int = 8
+    num_layers: int = 2
+    dropout: float = 0.10
+
+
+class TransformerFeatureExtractor(nn.Module):
+    def __init__(
+        self,
+        model_config: BasicTransformerFeatureExtractorModelConfig,
+        embedding_dim: int,
+        num_tokens: int,
+        max_length: int,
+    ) -> None:
+        super().__init__()
+
+        self.model_config = model_config
+        self.embedding_dim = embedding_dim
+        self.num_tokens = num_tokens
+        self.max_length = max_length
+
+        encoder_layers = TransformerEncoderLayer(
+            d_model=self.embedding_dim,
+            nhead=model_config.num_heads,
+            dim_feedforward=max_length,
+            dropout=model_config.dropout,
+            batch_first=True,
+        )
+        self.transformer_encoder = TransformerEncoder(
+            encoder_layer=encoder_layers, num_layers=model_config.num_layers
+        )
+
+    @property
+    def num_out_features(self) -> int:
+        return self.max_length * self.embedding_dim
+
+    def forward(self, input: Tensor) -> Tensor:
+        out = self.transformer_encoder(input)
         return out.flatten(1)
 
 

--- a/eir/setup/config.py
+++ b/eir/setup/config.py
@@ -38,7 +38,9 @@ from eir.models.fusion import FusionModelConfig
 from eir.models.fusion_linear import LinearFusionModelConfig
 from eir.models.fusion_mgmoe import MGMoEModelConfig
 from eir.models.omics.omics_models import get_omics_config_dataclass_mapping
-from eir.models.sequence.transformer_basic import BasicTransformerModelConfig
+from eir.models.sequence.transformer_basic import (
+    BasicTransformerFeatureExtractorModelConfig,
+)
 from eir.setup import schemas
 from eir.setup.presets import gln
 
@@ -419,7 +421,7 @@ def get_model_config_map() -> Dict[str, Type]:
         **mapping,
         **{
             "tabular": eir.models.tabular.tabular.TabularModelConfig,
-            "sequence-default": BasicTransformerModelConfig,
+            "sequence-default": BasicTransformerFeatureExtractorModelConfig,
         },
     }
 

--- a/eir/setup/schemas.py
+++ b/eir/setup/schemas.py
@@ -18,20 +18,24 @@ from eir.models.omics.omics_models import (
     Dataclass,
 )
 from eir.models.tabular.tabular import SimpleTabularModel, TabularModelConfig
+from eir.models.sequence.transformer_basic import (
+    BasicTransformerFeatureExtractorModelConfig,
+)
 
 al_input_configs = Sequence["InputConfig"]
 
 
 al_model_configs = Union[
-    Type[FusionModelConfig],
-    Type[MGMoEModelConfig],
-    Type[CNNModelConfig],
-    Type[LinearModelConfig],
-    Type[SimpleLCLModelConfig],
-    Type[LCLModelConfig],
-    Type[TabularModelConfig],
-    Type[IdentityModelConfig],
-    Type[Dataclass],
+    FusionModelConfig,
+    MGMoEModelConfig,
+    CNNModelConfig,
+    LinearModelConfig,
+    SimpleLCLModelConfig,
+    LCLModelConfig,
+    TabularModelConfig,
+    IdentityModelConfig,
+    BasicTransformerFeatureExtractorModelConfig,
+    Dataclass,
 ]
 
 al_models_classes = Union[
@@ -370,7 +374,6 @@ class SequenceInputDataConfig:
         included in the vocabulary. Note that this setting will not do anything if
         passing in ``vocab_file``.
 
-
     :param split_on:
         Which token to split the sequence on to generate separate tokens for the
         vocabulary.
@@ -381,6 +384,16 @@ class SequenceInputDataConfig:
 
     :param tokenizer_language:
         Which language rules the tokenizer should apply when tokenizing the raw data.
+
+    :param embedding_dim:
+        Which dimension to use for the embeddings. If ``None``, will autoamtically set
+        this value based on the number of tokens and attention heads.
+
+    :param window_size:
+        If set to more than 0, will apply a sliding window of feature
+        extraction over the input, meaning the model (e.g. transformer) will only
+        see a part of the input at a time. Can be Useful to avoid the O(n²)
+        complexity of transformers, as it becomes n_windows * O(window_size²) instead.
     """
 
     model_type: Literal["sequence-default"] = "sequence-default"
@@ -391,6 +404,10 @@ class SequenceInputDataConfig:
     split_on: str = " "
     tokenizer: al_tokenizer_choices = None
     tokenizer_language: Union[str, None] = None
+    position: Literal["encode", "embed"] = "encode"
+    position_dropout: float = 0.1
+    embedding_dim: int = None
+    window_size: int = 0
 
 
 @dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -270,12 +270,12 @@ def get_test_sequence_input_init(test_path: Path, split_to_test: bool) -> dict:
             "max_length": "max",
             "tokenizer_language": "en",
             "model_type": "sequence-default",
+            "embedding_dim": 8,
         },
         "model_config": {
             "num_heads": 2,
             "num_layers": 1,
             "dropout": 0.25,
-            "embedding_dim": 8,
         },
     }
 

--- a/tests/test_modelling/test_sequence_modelling.py
+++ b/tests/test_modelling/test_sequence_modelling.py
@@ -36,12 +36,12 @@ seed_everything(seed=0)
                 "input_configs": [
                     {
                         "input_info": {"input_name": "test_sequence"},
-                        "model_config": {"position": "encode"},
+                        "input_type_info": {"position": "encode"},
                     }
                 ],
             },
         },
-        # Case 2: Classification - Positional Embedding
+        # Case 2: Classification - Positional Embedding and Windowed
         {
             "injections": {
                 "global_configs": {
@@ -52,7 +52,7 @@ seed_everything(seed=0)
                 "input_configs": [
                     {
                         "input_info": {"input_name": "test_sequence"},
-                        "model_config": {"position": "embed"},
+                        "input_type_info": {"window_size": 16, "position": "embed"},
                     }
                 ],
             },


### PR DESCRIPTION
Used by sliding across a longer input sequence, while still encoding global position.